### PR TITLE
Add section about when lessons learned in the past do not apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Also often caused by a broken/missing/outdated Visual C++ redistributable. [Try 
 
 &nbsp;
 
+### `delta_time` includes dropped frames
+
+While GameMaker's animation system does not advance when frames are dropped, (such as while dragging the game's window around) the value of `delta_time` will. This means `delta_time` can get much larger than you might expect which can break timings in your game. You should cap `delta_time` to mitigate this problem.
+
+&nbsp;
+
 ### `<insert library name here>` is taking up 50% of a Step in the profiler and I am very worried about it.
 The GameMaker profiler is deceptive and the percentage measurement is nigh useless due to the way it's calculated. The bit that's actually important is the time taken to execute the function. If the execution time is less than 1ms then you're getting your knickers in a twist about nothing.
 
@@ -143,22 +149,4 @@ If you've created a mockup in Photoshop, Figma, GIMP, etc. and then tried to rep
 &nbsp;
 
 ### Nothing is drawing and I see "Draw failed due to invalid input layout" in the Output log.
-This happens when something you are drawing does not provide the attribute data that your shader needs. For example, if you apply a shader that expects texture coordinates, onto a draw_rectangle, it will fail. A common workaround is to have different versions for you shaders depending on what you're drawing (e.g. shd_basic, shd_textured, shd_textured_normals, etc)
-
-&nbsp;
-
-## Where common wisdom is defeated
-
-This section is for people who thought they knew better, but didn't, such as developers who attempt to apply previous programming experience to GameMaker.
-
-&nbsp;
-
-### `self` is not a reference
-
-The `self` keyword in GML is not a reference to an instance. It is a constant which tells the runtime to evaluate to the current value of the keyword `id`. To get a lasting reference to a specific instance, you have to use `id` directly.
-
-&nbsp;
-
-### `delta_time` includes dropped frames
-
-While GameMaker's animation system does not advance when frames are dropped, (such as while dragging the game's window around) the value of `delta_time` will. While this is part of its purpose, its also a detail that is easy to miss and can break your game when late or dropped frames cause it to become very large. Often, it is better to get passed game time by evaluating `game_get_speed()` once per Step Event.
+This happens when something you are drawing does not provide the attribute data that your shader needs. For example, if you apply a shader that expects texture coordinates, onto a draw_rectangle, it will fail. A common workaround is to have different versions for you shaders depending on what you're drawing (e.g. shd_basic, shd_textured, shd_textured_normals, etc).

--- a/README.md
+++ b/README.md
@@ -144,3 +144,21 @@ If you've created a mockup in Photoshop, Figma, GIMP, etc. and then tried to rep
 
 ### Nothing is drawing and I see "Draw failed due to invalid input layout" in the Output log.
 This happens when something you are drawing does not provide the attribute data that your shader needs. For example, if you apply a shader that expects texture coordinates, onto a draw_rectangle, it will fail. A common workaround is to have different versions for you shaders depending on what you're drawing (e.g. shd_basic, shd_textured, shd_textured_normals, etc)
+
+&nbsp;
+
+## Where common wisdom is defeated
+
+This section is for people who thought they knew better, but didn't, such as developers who attempt to apply previous programming experience to GameMaker.
+
+&nbsp;
+
+### `self` is not a reference
+
+The `self` keyword in GML is not a reference to an instance. It is a constant which tells the runtime to evaluate to the current value of the keyword `id`. To get a lasting reference to a specific instance, you have to use `id` directly.
+
+&nbsp;
+
+### `delta_time` includes dropped frames
+
+While GameMaker's animation system does not advance when frames are dropped, (such as while dragging the game's window around) the value of `delta_time` will. While this is part of its purpose, its also a detail that is easy to miss and can break your game when late or dropped frames cause it to become very large. Often, it is better to get passed game time by evaluating `game_get_speed()` once per Step Event.


### PR DESCRIPTION
I somehow managed to release an entire functioning game on Steam not knowing this very important detail about `self`.

The paragraph about `delta_time` might better fit under "Stability". Not sure.

I leave it to maintainers whether this info is even worthwhile to add, as both are a bit of an RTFM issue.